### PR TITLE
Remove legacy Brickimedia skins and Cavendish

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -112,21 +112,6 @@
 [submodule "Wisky"]
 	path = Wisky
 	url = https://bitbucket.org/wikiskripta/wisky.git
-[submodule "Custard"]
-	path = Custard
-	url = https://github.com/Brickimedia/Custard
-[submodule "DeepSea"]
-	path = DeepSea
-	url = https://github.com/Brickimedia/DeepSea
-[submodule "Lia"]
-	path = Lia
-	url = https://github.com/Brickimedia/Lia
-[submodule "Quartz"]
-	path = Quartz
-	url = https://github.com/Brickimedia/Quartz
-[submodule "Refreshed"]
-	path = Refreshed
-	url = https://github.com/Brickimedia/Refreshed
 [submodule "snapwikiskin"]
 	path = snapwikiskin
 	url = https://github.com/snapwiki/snapwikiskin

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,9 +34,6 @@
 [submodule "BlueLL"]
 	path = BlueLL
 	url = https://github.com/lingua-libre/BlueLL.git
-[submodule "Cavendish"]
-	path = Cavendish
-	url = https://github.com/DaSchTour/Cavendish.git
 [submodule "Citizen"]
 	path = Citizen
 	url = https://github.com/StarCitizenTools/mediawiki-skins-Citizen.git


### PR DESCRIPTION
For Brickimedia skins, see my comment at nonwmf-extensions/#25: these are either obsolete or the current version is maintained on WMF git/gerrit. Either way, these GitHub repos aren't used and haven't been used since 2017.

For Cavendish: it was recently moved to WMF git/gerrit, per https://github.com/DaSchTour/Cavendish/issues/33

cc @hexmode