### PR TITLE
Replace submodule for AtlasMuseum skin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://invent.kde.org/websites/aether-mediawiki.git
 [submodule "AtlasMuseum"]
 	path = AtlasMuseum
-	url = https://github.com/Atlasmuseum/AMV2.git
+	url = https://github.com/jdlrobson/mediawiki-skins-Atlasmuseum.git
 [submodule "BlueLL"]
 	path = BlueLL
 	url = https://github.com/lingua-libre/BlueLL.git


### PR DESCRIPTION
The one at https://github.com/jdlrobson/mediawiki-skins-Atlasmuseum.git has newer code, and appears to be the official repository for the skin (despite being labelled as a fork) - it's the one linked from https://www.mediawiki.org/wiki/Skin:AtlasMuseum .